### PR TITLE
Fix for AD membership population

### DIFF
--- a/lib/loginManager.cfc
+++ b/lib/loginManager.cfc
@@ -228,7 +228,7 @@ This is an lookup example for Active Directory. For it to work you will also nee
 			            
 		<cfif variables.pluginConfig.getSetting('syncMemberships') eq "True">			
 			<cfloop list="#rsUser.memberof#" index="i">
-			<cfif listFirst(i,"=") eq "CN">
+			<cfif trim(listFirst(i,"=")) eq "CN">
 				<cfset returnStruct.memberships=listappend(returnStruct.memberships,listLast(i,"="))>
 			</cfif>
 			</cfloop>


### PR DESCRIPTION
This is a simple fix for an issue I was seeing with Active Directory membership population. The way the memberOf attribute was being returned from CFLDAP, list values may or may not have a leading space.
